### PR TITLE
feate: Add deleteUser

### DIFF
--- a/src/controllers/delete-user.ts
+++ b/src/controllers/delete-user.ts
@@ -1,0 +1,38 @@
+import { ShortenedUrlRepositoryImpl } from '@/repositories/shortened-url-repository-impl'
+import { UserRepositoryImpl } from '@/repositories/user-repository-impl'
+import { DeleteUserUseCase } from '@/use-cases/delete-user'
+import { InvalidCredentials } from '@/use-cases/errors/invalid-credentials-erros'
+import { UserNotExists } from '@/use-cases/errors/user-not-exists'
+import { FastifyReply, FastifyRequest } from 'fastify'
+
+import { z } from 'zod'
+
+export async function deleteUser(request: FastifyRequest, reply: FastifyReply) {
+  const deleteUserBodySchema = z.object({
+    password: z.string(),
+  })
+
+  const { password } = deleteUserBodySchema.parse(request.body)
+
+  try {
+    const shortenedUrlRepository = new ShortenedUrlRepositoryImpl()
+    const userRepository = new UserRepositoryImpl()
+    const deleteUserUseCase = new DeleteUserUseCase(
+      userRepository,
+      shortenedUrlRepository,
+    )
+
+    await deleteUserUseCase.execute(request.user.sub, password)
+
+    reply.send({ message: 'Usuário deletado com sucesso' })
+  } catch (error) {
+    if (error instanceof InvalidCredentials) {
+      return reply.status(401).send({ message: error.message })
+    }
+
+    if (error instanceof UserNotExists) {
+      return reply.status(404).send({ message: error.message })
+    }
+    throw error
+  }
+}

--- a/src/repositories/in-memory/in-memory-shortened-url-repository.ts
+++ b/src/repositories/in-memory/in-memory-shortened-url-repository.ts
@@ -66,4 +66,8 @@ export class InMemoryShortenedUrlRepository implements ShortenedUrlRepository {
       ) || null
     )
   }
+
+  async deleteManyUrlsByUserId(userId: string): Promise<void> {
+    this.urls = this.urls.filter((url) => url.user_id !== userId)
+  }
 }

--- a/src/repositories/in-memory/in-memory-user-repository.ts
+++ b/src/repositories/in-memory/in-memory-user-repository.ts
@@ -56,4 +56,8 @@ export class InMemoryUserRepository implements UserRepository {
 
     return Promise.resolve(user)
   }
+
+  async deleteUser(userId: string): Promise<void> {
+    this.items = this.items.filter((user) => user.id !== userId)
+  }
 }

--- a/src/repositories/shortened-url-repository-impl.ts
+++ b/src/repositories/shortened-url-repository-impl.ts
@@ -104,6 +104,12 @@ export class ShortenedUrlRepositoryImpl implements ShortenedUrlRepository {
     })
   }
 
+  async deleteManyUrlsByUserId(userId: string): Promise<void> {
+    await this.prisma.shortenedUrl.deleteMany({
+      where: { user_id: userId },
+    })
+  }
+
   private prisma: PrismaClient
   constructor() {
     this.prisma = new PrismaClient()

--- a/src/repositories/shortened-url-repository.ts
+++ b/src/repositories/shortened-url-repository.ts
@@ -26,4 +26,6 @@ export interface ShortenedUrlRepository {
     newShortUrl: string,
     newTitleUrl: string,
   ): Promise<ShortenedUrl>
+
+  deleteManyUrlsByUserId(userId: string): Promise<void>
 }

--- a/src/repositories/user-repository-impl.ts
+++ b/src/repositories/user-repository-impl.ts
@@ -35,6 +35,10 @@ export class UserRepositoryImpl implements UserRepository {
     return user
   }
 
+  async deleteUser(userId: string): Promise<void> {
+    await this.prisma.user.delete({ where: { id: userId } })
+  }
+
   private prisma: PrismaClient
 
   constructor() {

--- a/src/repositories/user-repository.ts
+++ b/src/repositories/user-repository.ts
@@ -10,4 +10,6 @@ export interface UserRepository {
     email?: string,
     password?: string,
   ): Promise<User | null>
+
+  deleteUser(userId: string): Promise<void>
 }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -13,6 +13,7 @@ import { verifyJTW } from './middleware/verify-jwt'
 import { refresh } from './controllers/refresh'
 import { updateProfile } from './controllers/update-profile'
 import { getUserProfile } from './controllers/get-user-profile'
+import { deleteUser } from './controllers/delete-user'
 
 export async function appRoutes(app: FastifyInstance) {
   app.post(
@@ -370,5 +371,32 @@ export async function appRoutes(app: FastifyInstance) {
       },
     },
     getUserProfile,
+  )
+
+  app.delete(
+    '/v1/user',
+    {
+      onRequest: [verifyJTW],
+      schema: {
+        tags: ['Users'],
+        security: [{ BearerAuth: [] }],
+        body: {
+          type: 'object',
+          properties: {
+            password: { type: 'string' },
+          },
+          required: ['password'],
+        },
+        response: {
+          200: {
+            type: 'object',
+            properties: {
+              message: { type: 'string' },
+            },
+          },
+        },
+      },
+    },
+    deleteUser,
   )
 }

--- a/src/use-cases/delete-user.spec.ts
+++ b/src/use-cases/delete-user.spec.ts
@@ -1,0 +1,91 @@
+import bcrypt from 'bcryptjs'
+import { InMemoryUserRepository } from '@/repositories/in-memory/in-memory-user-repository'
+import { DeleteUserUseCase } from './delete-user'
+import { expect, describe, it, beforeEach } from 'vitest'
+import { UserNotExists } from './errors/user-not-exists'
+import { InMemoryShortenedUrlRepository } from '@/repositories/in-memory/in-memory-shortened-url-repository'
+import { InvalidCredentials } from './errors/invalid-credentials-erros'
+
+let userRepository: InMemoryUserRepository
+let shortenedUrlRepository: InMemoryShortenedUrlRepository
+let sut: DeleteUserUseCase
+
+describe('Delete User Use Case', () => {
+  beforeEach(() => {
+    userRepository = new InMemoryUserRepository()
+    shortenedUrlRepository = new InMemoryShortenedUrlRepository()
+    sut = new DeleteUserUseCase(userRepository, shortenedUrlRepository)
+  })
+
+  it('should delete user', async () => {
+    const user = await userRepository.createUser({
+      id: 'user-id',
+      name: 'John Doe',
+      email: 'example@example.com',
+      password: bcrypt.hashSync('123456', 8),
+      created_at: new Date(),
+    })
+
+    expect(async () => {
+      await sut.execute(user.id, '123456')
+    }).not.toThrow()
+  })
+
+  it('should delete all user urls', async () => {
+    const user = await userRepository.createUser({
+      id: 'user-id',
+      name: 'John Doe',
+      email: 'example@example.com',
+      password: bcrypt.hashSync('123456', 8),
+      created_at: new Date(),
+    })
+
+    await shortenedUrlRepository.createShortenedUrl({
+      id: '1',
+      title: 'Example',
+      long_url: 'http://example.com',
+      short_url: 'abc',
+      user_id: user.id,
+      created_at: new Date(),
+    })
+
+    await shortenedUrlRepository.createShortenedUrl({
+      id: '2',
+      title: 'Example 2',
+      long_url: 'http://example2.com',
+      short_url: 'def',
+      user_id: user.id,
+      created_at: new Date(),
+    })
+
+    await sut.execute(user.id, '123456')
+
+    const urls = await shortenedUrlRepository.findAllByUserId(user.id)
+
+    expect(urls).toHaveLength(0)
+
+    const deleteUser = await userRepository.findById(user.id)
+
+    expect(deleteUser).toBeNull()
+  })
+
+  it('should throw if password is invalid', async () => {
+    const user = await userRepository.createUser({
+      id: 'user-id',
+      name: 'John Doe',
+      email: 'example@example.com',
+      password: bcrypt.hashSync('123456', 8),
+      created_at: new Date(),
+    })
+
+    expect(async () => {
+      await sut.execute(user.id, 'invalid-password')
+    }).rejects.toThrowError(InvalidCredentials)
+  })
+
+  it('should throw if user does not exist', async () => {
+    expect(async () => {
+      await sut.execute('user-id', '123456')
+    }).rejects.toThrowError(UserNotExists)
+  })
+})

--- a/src/use-cases/delete-user.ts
+++ b/src/use-cases/delete-user.ts
@@ -1,0 +1,31 @@
+import bcrypt from 'bcryptjs'
+import { UserRepository } from '@/repositories/user-repository'
+import { UserNotExists } from './errors/user-not-exists'
+import { InvalidCredentials } from './errors/invalid-credentials-erros'
+import { ShortenedUrlRepository } from '@/repositories/shortened-url-repository'
+
+export class DeleteUserUseCase {
+  // eslint-disable-next-line prettier/prettier
+  constructor(private userRepository: UserRepository, private shortenedUrlRepository: ShortenedUrlRepository) { }
+
+
+
+  async execute(userId: string, password: string): Promise<void> {
+    const user = await this.userRepository.findById(userId)
+
+    if (!user) {
+      throw new UserNotExists()
+    }
+
+    const isPasswordValid = bcrypt.compareSync(password, user.password)
+    console.log(isPasswordValid)
+
+    if (!isPasswordValid) {
+      throw new InvalidCredentials()
+    }
+
+    await this.shortenedUrlRepository.deleteManyUrlsByUserId(userId)
+
+    await this.userRepository.deleteUser(userId)
+  }
+}


### PR DESCRIPTION
Claro, aqui está a tradução para inglês da descrição e das mudanças propostas:

---

## Description

This pull request adds a feature to delete the user account, along with all related records, according to the business requirements.

## Proposed Changes

- Adds a new endpoint in the API to delete the user account.
- Implements the necessary logic in the backend to delete the user account and all related records (shortened URLs).
- Implements validation of the user's password to ensure that only the user themselves can delete their account.
- Provides appropriate feedback to the user after the account deletion, informing whether the operation was successful or not.

## Motivation and Context

User account deletion is an essential feature in many systems, and this implementation aims to provide a secure and effective way for users to remove their accounts, along with all associated data.
